### PR TITLE
Don't fail on null value gauges - print to log

### DIFF
--- a/src/main/java/com/codahale/metrics/riemann/RiemannReporter.java
+++ b/src/main/java/com/codahale/metrics/riemann/RiemannReporter.java
@@ -400,8 +400,10 @@ public class RiemannReporter extends ScheduledReporter {
             reporter.name().metric((Integer) o).send();
         } else if (o instanceof Long) {
             reporter.name().metric((Long) o).send();
+        } else if (o == null) {
+            log.debug("Gauge {} has a null value", name);
         } else {
-            log.debug("Gauge was of an unknown type: {}", o.getClass().toString());
+            log.debug("Gauge {} was of an unknown type: {} ", name, o.getClass().toString());
         }
     }
 }

--- a/src/test/java/com/codahale/metrics/riemann/RiemannReporterTest.java
+++ b/src/test/java/com/codahale/metrics/riemann/RiemannReporterTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -70,18 +71,31 @@ public class RiemannReporterTest {
 
     @Test
     public void doesNotReportStringGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge("value")),
-                        this.<Counter>map(),
-                        this.<Histogram>map(),
-                        this.<Meter>map(),
-                        this.<Timer>map());
+        reportGauge("value");
+        verifyNoReporting();
+    }
 
+    @Test
+    public void doesNotReportNullGaugeValues() throws Exception {
+        reportGauge(null);
+        verifyNoReporting();
+    }
+
+    private void verifyNoReporting() throws IOException {
         final InOrder inOrder = inOrder(riemann, eventDSL, client);
         inOrder.verify(riemann).connect();
         inOrder.verify(client, never()).event();
         verifyZeroInteractions(eventDSL);
         inOrder.verify(client).flush();
         inOrder.verifyNoMoreInteractions();
+    }
+
+    private void reportGauge(Object value) {
+        reporter.report(map("gauge", gauge(value)),
+                        this.<Counter>map(),
+                        this.<Histogram>map(),
+                        this.<Meter>map(),
+                        this.<Timer>map());
     }
 
     @Test


### PR DESCRIPTION
A null valued Gauge would get to the final if block - where it would fail on NPE when issuing the log ```o.getClass().toString()```  - this causes the reporter to fail
Also added the metric name for log messages - makes finding the relevant gauge much easier

As a side note - I think the reporters should be extracted from here to https://github.com/dropwizard/metrics
it would make it easier to find & that way you don't get metric2 when you need metric3 etc
