### PR TITLE
Fix semaphore leak for TcpTransport

### DIFF
--- a/src/main/java/com/aphyr/riemann/client/TcpTransport.java
+++ b/src/main/java/com/aphyr/riemann/client/TcpTransport.java
@@ -289,7 +289,8 @@ public class TcpTransport implements AsynchronousTransport {
         return promise;
       }
 
-      // No channels
+      // No channels available, release the slot.
+      limiter.release();
       promise.deliver(new IOException("no channels available"));
       return promise;
     }


### PR DESCRIPTION
In the case where no channel is available, the writeLimiter
is acquired but not released and would cause all future writes
to fail with `OverloadedException` even when the connection comes
back.