### PR TITLE
Fix Maven javadoc error - Remove Link to Collection

### DIFF
--- a/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/RiemannReporter.java
+++ b/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/RiemannReporter.java
@@ -174,7 +174,7 @@ public class RiemannReporter extends ScheduledReporter {
         /**
          * Tags to attach to events.
          *
-         * @param tags a {@link Collection<String>}
+         * @param tags a Collection<String>
          * @return {@code this}
          */
         public Builder tags(Collection<String> tags) {
@@ -239,7 +239,7 @@ public class RiemannReporter extends ScheduledReporter {
 
     private interface EventClosure {
         public EventDSL name(String... components);
-    };
+    }
 
 
     private EventClosure newEvent(final String metricName, final long timestamp, final String metricType) {


### PR DESCRIPTION
@aphyr 
TLDR - This seems abit hacky but removes the warning/failure.

This was the failing javadoc sign, I'm not sure why it fails as it seems rather trivial. 
to be honest I don't find the Javadoc itself very helpful anyhow, So for now I've removed the ```@link``` annotation. 

Executing  ```mvn package```  locally - gave a *Warning* about this prior to the change, no warnings after (including the other one you posted).
I guess this is due to some difference in mvn setup on warning levels. it'd be best if there was a travis/something build so we'd be on common ground here. I'll try to set one up. 


