### PR TITLE
Fix Javadoc error

### DIFF
--- a/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/RiemannReporter.java
+++ b/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/RiemannReporter.java
@@ -174,7 +174,7 @@ public class RiemannReporter extends ScheduledReporter {
         /**
          * Tags to attach to events.
          *
-         * @param tags a Collection<String>
+         * @param tags a {@code Collection<String>}
          * @return {@code this}
          */
         public Builder tags(Collection<String> tags) {


### PR DESCRIPTION
mvn install fails with error:
1 error
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Riemann Java Client ................................ SUCCESS [  3.492 s]
[INFO] riemann-java-client ................................ SUCCESS [ 10.594 s]
[INFO] metrics2-riemann-reporter .......................... SUCCESS [  2.006 s]
[INFO] metrics3-riemann-reporter .......................... FAILURE [  2.548 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 24.921 s
[INFO] Finished at: 2015-06-11T17:19:30+03:00
[INFO] Final Memory: 53M/500M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9.1:jar (attach-javadocs) on project metrics3-riemann-reporter: MavenReportException: Error while creating archive:
[ERROR] Exit code: 1 - /home/vkorenev/Projects/Riemann/riemann-java-client/metrics3-riemann-reporter/src/main/java/com/codahale/metrics/riemann/RiemannReporter.java:177: error: unknown tag: String
[ERROR] * @param tags a Collection<String>
[ERROR] ^
[ERROR] 
[ERROR] Command line was: /usr/lib/jvm/java-8-oracle/jre/../bin/javadoc @options @packages
