### PR TITLE
update README for protobuf requirement

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -86,4 +86,4 @@ which automatically bundles events together into messages for you.
 
 # Hacking
 
-You'll need [protoc 2.5.0](http://code.google.com/p/protobuf/downloads/detail?name=protobuf-2.5.0.tar.bz2&can=2&q=). After that, `mvn package` should build a JAR, and `mvn install` will drop it in your local repository.
+You'll need [protobuf 2.6.1](https://github.com/google/protobuf). After that, `mvn package` should build a JAR, and `mvn install` will drop it in your local repository.


### PR DESCRIPTION
Update the document of protobuf requirement to 2.6.1. 

class com/google/protobuf/ProtocolStringList is introduced in 2.6.0. 

There is an exception when 2.5.0 is used.

Exception in thread "main" java.lang.NoClassDefFoundError: com/google/protobuf/ProtocolStringList, compiling:(riemann/codec.clj:1:1)