### PR TITLE
Fixed promise delivery for RiemannBatchClient

### DIFF
--- a/riemann-java-client/src/main/java/com/aphyr/riemann/client/ChainPromise.java
+++ b/riemann-java-client/src/main/java/com/aphyr/riemann/client/ChainPromise.java
@@ -36,8 +36,8 @@ import java.io.IOException;
 public class ChainPromise<T> implements IPromise<T> {
   public final IPromise<IPromise<T>> inner = new Promise<IPromise<T>>();
 
-  public void attach(final IPromise<T> inner) {
-    inner.deliver(inner);
+  public void attach(final IPromise<T> innerValue) {
+    inner.deliver(innerValue);
   }
 
   @Override

--- a/riemann-java-client/src/test/java/riemann/java/client/tests/BatchClientPromiseTest.java
+++ b/riemann-java-client/src/test/java/riemann/java/client/tests/BatchClientPromiseTest.java
@@ -1,0 +1,70 @@
+package riemann.java.client.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import com.aphyr.riemann.client.IPromise;
+import com.aphyr.riemann.client.IRiemannClient;
+import com.aphyr.riemann.client.RiemannBatchClient;
+import com.aphyr.riemann.client.RiemannClient;
+import com.aphyr.riemann.client.ServerError;
+import com.aphyr.riemann.client.UnsupportedJVMException;
+
+import com.aphyr.riemann.Proto.Event;
+import com.aphyr.riemann.Proto.Msg;
+
+public class BatchClientPromiseTest {
+  @Test
+  public void sendEventsTest() throws Exception, IOException, InterruptedException, ServerError, UnsupportedJVMException {
+    final ArrayList<Event> events = new ArrayList<Event>();
+    final ArrayList<IPromise<Msg>> promises = new ArrayList<IPromise<Msg>>();
+
+    final Server server = new OkServer();
+    IRiemannClient client = null;
+
+    final int BATCH_SIZE = 10;
+    final int NUM_EVENTS = 15;
+    try {
+      client = new RiemannBatchClient(RiemannClient.tcp(server.start()),
+                                      BATCH_SIZE);
+      client.connect();
+      {
+        final Event e = Util.createEvent();
+        events.add(e);
+        IPromise<Msg> promise = client.sendEvent(e);
+        // First event should be sitting in the buffer, not sent yet.
+        assertEquals(null, promise.deref(10, (Object) null));
+        promises.add(promise);
+      }
+      for (int i = 1; i < NUM_EVENTS; i++) {
+        final Event e = Util.createEvent();
+        events.add(e);
+        promises.add(client.sendEvent(e));
+      }
+      client.flush();
+      for (int i = 0; i < events.size(); i++) {
+        Msg rsp = promises.get(i).deref(10, TimeUnit.MILLISECONDS,
+                                        Msg.newBuilder().setOk(false).build());
+        assertTrue(!rsp.hasOk() || rsp.getOk());
+      }
+      for (int i = 0; i < events.size(); ) {
+        final int expecting = Math.min(events.size() - i, BATCH_SIZE);
+        Msg recv = server.received.poll();
+        assertEquals(expecting, recv.getEventsCount());
+        for (int j = 0; j < expecting; i++, j++) {
+          assertEquals(events.get(i), recv.getEvents(j));
+        }
+      }
+    } finally {
+      if (client != null) {
+        client.close();
+      }
+      server.stop();
+    }
+  }
+}

--- a/riemann-java-client/src/test/java/riemann/java/client/tests/ChainPromiseTest.java
+++ b/riemann-java-client/src/test/java/riemann/java/client/tests/ChainPromiseTest.java
@@ -1,0 +1,57 @@
+package riemann.java.client.tests;
+
+import com.aphyr.riemann.client.ChainPromise;
+import com.aphyr.riemann.client.Promise;
+import java.lang.Runnable;
+import java.lang.Thread;
+import org.junit.Before;
+import org.junit.Test;
+import static junit.framework.Assert.assertEquals;
+import java.io.IOException;
+
+public class ChainPromiseTest {
+
+  private ChainPromise<String> cp;
+
+  @Before
+  public void setUp() {
+    cp = new ChainPromise<String>();
+  }
+
+  @Test
+  public void singleTest() throws IOException {
+    // A previous version of ChainPromise didn't properly attach the
+    // inner promise, this problem was visible in
+    // BatchClientPromiseTest
+    Promise<String> p = new Promise<String>();
+    cp.attach(p);
+    p.deliver("foo");
+    assertEquals("foo", cp.deref(10, (Object) null));
+  }
+
+  @Test
+  public void threadTest() throws IOException {
+    final Promise<String> p = new Promise<String>();
+    new Thread(new Runnable() {
+      public void run() {
+        try {
+          Thread.sleep(100);
+        } catch (InterruptedException e) {
+          System.out.println("interrupted");
+        }
+        p.deliver("bar");
+      }
+    }).start();
+    new Thread(new Runnable() {
+      public void run() {
+        try {
+          Thread.sleep(100);
+        } catch (InterruptedException e) {
+          System.out.println("interrupted");
+        }
+        cp.attach(p);
+      }
+    }).start();
+    assertEquals("bar", p.deref(200, (Object) null));
+  }
+}


### PR DESCRIPTION
The ChainPromise was trying to deliver a promise to itself, so the client never got the result of the send.

This patch includes the fix, a low level, and a high level test.