### PR TITLE
Using Daemon Threads in HashedWheelTimer

### DIFF
--- a/riemann-java-client/src/main/java/com/aphyr/riemann/client/HashedWheelTimerFactory.java
+++ b/riemann-java-client/src/main/java/com/aphyr/riemann/client/HashedWheelTimerFactory.java
@@ -1,0 +1,32 @@
+package com.aphyr.riemann.client;
+
+import org.jboss.netty.util.HashedWheelTimer;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * Creates hashed wheel timers
+ */
+public class HashedWheelTimerFactory {
+
+    public static ThreadFactory daemonThreadFactory = new ThreadFactory() {
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread retVal = Executors.defaultThreadFactory().newThread(r);
+            retVal.setDaemon(true);
+
+            return retVal;
+        }
+    };
+
+    /**
+     * Creates hashed wheel timer that uses daemon threads
+     *
+     * @return HashedWheelTimer
+     */
+    public static HashedWheelTimer CreateDaemonHashedWheelTimer() {
+        return new HashedWheelTimer(daemonThreadFactory);
+    }
+
+}

--- a/riemann-java-client/src/main/java/com/aphyr/riemann/client/TcpTransport.java
+++ b/riemann-java-client/src/main/java/com/aphyr/riemann/client/TcpTransport.java
@@ -151,7 +151,7 @@ public class TcpTransport implements AsynchronousTransport {
         Executors.newCachedThreadPool());
 
     // Timer
-    timer = new HashedWheelTimer();
+    timer = HashedWheelTimerFactory.CreateDaemonHashedWheelTimer();
 
     // Create bootstrap
     bootstrap = new ClientBootstrap(channelFactory);

--- a/riemann-java-client/src/main/java/com/aphyr/riemann/client/UdpTransport.java
+++ b/riemann-java-client/src/main/java/com/aphyr/riemann/client/UdpTransport.java
@@ -94,7 +94,7 @@ public class UdpTransport implements SynchronousTransport {
         Executors.newCachedThreadPool());
 
     // Timer
-    timer = new HashedWheelTimer();
+    timer = HashedWheelTimerFactory.CreateDaemonHashedWheelTimer();
 
     // Create bootstrap
     bootstrap = new ConnectionlessBootstrap(channelFactory);

--- a/riemann-java-client/src/test/java/riemann/java/client/tests/HashedWheelTimerFactoryTest.java
+++ b/riemann-java-client/src/test/java/riemann/java/client/tests/HashedWheelTimerFactoryTest.java
@@ -1,0 +1,20 @@
+package riemann.java.client.tests;
+
+import com.aphyr.riemann.client.HashedWheelTimerFactory;
+import com.aphyr.riemann.client.Promise;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+public class HashedWheelTimerFactoryTest {
+
+    @Test
+    public void shouldCreateDaemonThreads() throws IOException {
+        Thread thread = HashedWheelTimerFactory.daemonThreadFactory.newThread(null);
+        assertTrue("Thread should be a daemon thread", thread.isDaemon());
+    }
+
+}


### PR DESCRIPTION
Because the default `HashedWheelTimer` c'tor creates non daemon threads, And it prevents shutdown on an unhandled exception.